### PR TITLE
Feature: Pendaftaran

### DIFF
--- a/src/main/java/com/apb15/neorekruit/controller/PendaftaranController.java
+++ b/src/main/java/com/apb15/neorekruit/controller/PendaftaranController.java
@@ -1,0 +1,78 @@
+package com.apb15.neorekruit.controller;
+
+import com.apb15.neorekruit.dto.pendaftaran.UpdateStatus;
+import com.apb15.neorekruit.model.Pendaftaran;
+import com.apb15.neorekruit.security.JWTUtils;
+import com.apb15.neorekruit.service.PendaftaranService;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.ObjectNotFoundException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/rekrutmen/{idRekrutmen}/pendaftaran")
+@RequiredArgsConstructor
+public class PendaftaranController {
+    private final PendaftaranService pendaftaranService;
+
+    @PostMapping
+    public ResponseEntity<Pendaftaran> createPendaftaran(@PathVariable("idRekrutmen") Long idRekrutmen,
+                                                         @RequestBody Pendaftaran pendaftaran,
+                                                         @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        try {
+            var token = authHeader.substring("Bearer ".length());
+            var emailPendaftar = JWTUtils.decodeJWTToken(token).getSubject();
+
+            var createdPendaftaran = pendaftaranService.createPendaftaran(idRekrutmen, emailPendaftar, pendaftaran);
+
+            URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentContextPath()
+                    .path(String.format("/rekrutmen/%s/pendaftaran", idRekrutmen))
+                    .toUriString());
+
+            return ResponseEntity.created(uri).body(createdPendaftaran);
+        } catch (RuntimeException exception) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Cannot create pendaftaran", exception);
+        }
+    }
+
+    @GetMapping("/{idPendaftaran}")
+    public ResponseEntity<Pendaftaran> getPendaftaranForRekrutmenById(@PathVariable("idPendaftaran") Long idPendaftaran) {
+        try {
+            var pendaftaran = pendaftaranService.findPendaftaranById(idPendaftaran);
+
+            return ResponseEntity.ok().body(pendaftaran);
+        } catch (ObjectNotFoundException exception) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PutMapping("/{idPendaftaran}")
+    public ResponseEntity<Pendaftaran> updatePendaftaran(@PathVariable("idRekrutmen") Long idRekrutmen,
+                                                         @PathVariable("idPendaftaran") Long idPendaftaran,
+                                                         @RequestBody Pendaftaran pendaftaran) {
+        try {
+            var updatedPengumuman = pendaftaranService.updatePendaftaran(idRekrutmen, idPendaftaran, pendaftaran);
+
+            return ResponseEntity.ok().body(updatedPengumuman);
+        } catch (ObjectNotFoundException exception) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Cannot update pendaftaran", exception);
+        }
+    }
+
+    @PostMapping("/{idPendaftaran}/ubahstatus")
+    public ResponseEntity<?> ubahStatusPendaftaran(@PathVariable("idPendaftaran") Long idPendaftaran,
+                                                   @RequestBody UpdateStatus status) {
+        try {
+            pendaftaranService.changeStatusPendaftaran(idPendaftaran, status.getStatus());
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException exception) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Pendaftaran not found", exception);
+        }
+    }
+}

--- a/src/main/java/com/apb15/neorekruit/controller/PenggunaController.java
+++ b/src/main/java/com/apb15/neorekruit/controller/PenggunaController.java
@@ -6,13 +6,17 @@ import com.apb15.neorekruit.model.Pendaftar;
 import com.apb15.neorekruit.model.Pengguna;
 import com.apb15.neorekruit.model.Rekruter;
 import com.apb15.neorekruit.model.Role;
+import com.apb15.neorekruit.security.JWTUtils;
 import com.apb15.neorekruit.service.PendaftarService;
 import com.apb15.neorekruit.service.PenggunaService;
 import com.apb15.neorekruit.service.RekruterService;
 import com.apb15.neorekruit.service.RoleService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -30,9 +34,20 @@ public class PenggunaController {
     private final RekruterService rekruterService;
     private final PendaftarService pendaftarSevice;
 
-    @GetMapping
-    public ResponseEntity<List<Pengguna>> getAllPengguna() {
-        return ResponseEntity.ok().body(penggunaService.getAllPengguna());
+    @GetMapping("/rekruter")
+    @ResponseBody
+    public ResponseEntity<?> findRekrutmenCreated(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        try {
+            var token = authHeader.substring("Bearer ".length());
+            var emailPendaftar = JWTUtils.decodeJWTToken(token).getSubject();
+
+            var rekruter = rekruterService.findByEmail(emailPendaftar);
+            var rekrutmenCreated = rekruter.getRekrutmen();
+
+            return ResponseEntity.ok().body(rekrutmenCreated);
+        } catch (RuntimeException exception) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Cannot get Pendaftaran", exception);
+        }
     }
 
     @PostMapping("/rekruter")
@@ -66,6 +81,22 @@ public class PenggunaController {
             return ResponseEntity.created(uri).body(createdRekruter);
         } catch (IllegalStateException exception) {
             return null;
+        }
+    }
+
+    @GetMapping("/pendaftar")
+    @ResponseBody
+    public ResponseEntity<?> findPendaftaranCreated(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        try {
+            var token = authHeader.substring("Bearer ".length());
+            var emailPendaftar = JWTUtils.decodeJWTToken(token).getSubject();
+
+            var pendaftar = pendaftarSevice.findByEmail(emailPendaftar);
+            var pendaftaranCreated = pendaftar.getMendaftar();
+
+            return ResponseEntity.ok().body(pendaftaranCreated);
+        } catch (RuntimeException exception) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Cannot get Pendaftaran", exception);
         }
     }
 

--- a/src/main/java/com/apb15/neorekruit/dto/RoleToUser.java
+++ b/src/main/java/com/apb15/neorekruit/dto/RoleToUser.java
@@ -1,9 +1,0 @@
-package com.apb15.neorekruit.dto;
-
-import lombok.Data;
-
-@Data
-public class RoleToUser {
-    private String email;
-    private String roleName;
-}

--- a/src/main/java/com/apb15/neorekruit/dto/pendaftaran/UpdateStatus.java
+++ b/src/main/java/com/apb15/neorekruit/dto/pendaftaran/UpdateStatus.java
@@ -1,0 +1,9 @@
+package com.apb15.neorekruit.dto.pendaftaran;
+
+import com.apb15.neorekruit.model.StatusPenerimaan;
+import lombok.Getter;
+
+@Getter
+public class UpdateStatus {
+    private StatusPenerimaan status;
+}

--- a/src/main/java/com/apb15/neorekruit/model/Pendaftar.java
+++ b/src/main/java/com/apb15/neorekruit/model/Pendaftar.java
@@ -1,5 +1,6 @@
 package com.apb15.neorekruit.model;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,10 +17,10 @@ import java.util.Collection;
 @AllArgsConstructor
 public class Pendaftar {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
     @OneToOne
+    @MapsId
     @JoinColumn(name = "pengguna_email", referencedColumnName = "email")
     private Pengguna pengguna;
 
@@ -35,6 +36,7 @@ public class Pendaftar {
     @Column
     private String kontak;
 
-    @OneToMany(mappedBy = "pendaftar", orphanRemoval = true)
+    @OneToMany(mappedBy = "pendaftar")
+    @JsonManagedReference("pendaftaran-pendaftar")
     private Collection<Pendaftaran> mendaftar = new ArrayList<>();
 }

--- a/src/main/java/com/apb15/neorekruit/model/Pendaftaran.java
+++ b/src/main/java/com/apb15/neorekruit/model/Pendaftaran.java
@@ -1,7 +1,7 @@
 package com.apb15.neorekruit.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import lombok.Builder;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import javax.persistence.*;
@@ -10,28 +10,29 @@ import javax.persistence.*;
 @Data
 public class Pendaftaran {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column
+    @JsonProperty("link_cv")
     private String linkCV;
 
     @Column
+    @JsonProperty("link_tugas")
     private String linkTugas;
 
     @Column
-    private String statusPenerimaan; // Good if ENUM
-
-    @Column
-    private String nilai;
+    @Enumerated(EnumType.STRING)
+    private StatusPenerimaan statusPenerimaan = StatusPenerimaan.DIPROSES;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "pendaftar_id", nullable = false)
+    @JsonBackReference("pendaftaran-pendaftar")
     private Pendaftar pendaftar;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "rekrutmen_id", nullable = false)
-    @JsonBackReference
+    @JsonBackReference("pendaftaran-rekrutmen")
     private Rekrutmen rekrutmen;
 
 }

--- a/src/main/java/com/apb15/neorekruit/model/Rekruter.java
+++ b/src/main/java/com/apb15/neorekruit/model/Rekruter.java
@@ -17,11 +17,10 @@ import java.util.Collection;
 @AllArgsConstructor
 public class Rekruter implements Serializable {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(nullable = false)
     private Long id;
 
     @OneToOne
+    @MapsId
     @JoinColumn(name = "pengguna_email", referencedColumnName = "email")
     private Pengguna pengguna;
 

--- a/src/main/java/com/apb15/neorekruit/model/Rekrutmen.java
+++ b/src/main/java/com/apb15/neorekruit/model/Rekrutmen.java
@@ -2,7 +2,6 @@ package com.apb15.neorekruit.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
@@ -60,11 +59,11 @@ public class Rekrutmen {
     @JsonProperty("link_wawancara")
     private String linkWawancara;
 
-    @JsonManagedReference("pendaftaran-rekrutmen")
+    @JsonIgnore
     @OneToMany(mappedBy = "rekrutmen", orphanRemoval = true, fetch = FetchType.LAZY)
     private Collection<Pendaftaran> pendaftaranRekrutmen = new ArrayList<>();
 
-    @JsonManagedReference
+    @JsonIgnore
     @OneToMany(mappedBy = "rekrutmen", orphanRemoval = true, fetch = FetchType.LAZY)
     private Collection<Pengumuman> pengumumanRekrutmen = new ArrayList<>();
 }

--- a/src/main/java/com/apb15/neorekruit/model/Rekrutmen.java
+++ b/src/main/java/com/apb15/neorekruit/model/Rekrutmen.java
@@ -60,7 +60,7 @@ public class Rekrutmen {
     @JsonProperty("link_wawancara")
     private String linkWawancara;
 
-    @JsonManagedReference
+    @JsonManagedReference("pendaftaran-rekrutmen")
     @OneToMany(mappedBy = "rekrutmen", orphanRemoval = true, fetch = FetchType.LAZY)
     private Collection<Pendaftaran> pendaftaranRekrutmen = new ArrayList<>();
 

--- a/src/main/java/com/apb15/neorekruit/model/StatusPenerimaan.java
+++ b/src/main/java/com/apb15/neorekruit/model/StatusPenerimaan.java
@@ -1,0 +1,7 @@
+package com.apb15.neorekruit.model;
+
+public enum StatusPenerimaan {
+    DIPROSES,
+    TIDAK_DITERIMA,
+    DITERIMA
+}

--- a/src/main/java/com/apb15/neorekruit/repository/PendaftarRepository.java
+++ b/src/main/java/com/apb15/neorekruit/repository/PendaftarRepository.java
@@ -1,8 +1,11 @@
 package com.apb15.neorekruit.repository;
 
 import com.apb15.neorekruit.model.Pendaftar;
+import com.apb15.neorekruit.model.Pengguna;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PendaftarRepository extends JpaRepository<Pendaftar, Long> {
+import java.util.Optional;
 
+public interface PendaftarRepository extends JpaRepository<Pendaftar, Long> {
+    Optional<Pendaftar> findPendaftarByPengguna(Pengguna pengguna);
 }

--- a/src/main/java/com/apb15/neorekruit/repository/PendaftaranRepository.java
+++ b/src/main/java/com/apb15/neorekruit/repository/PendaftaranRepository.java
@@ -1,0 +1,11 @@
+package com.apb15.neorekruit.repository;
+
+import com.apb15.neorekruit.model.Pendaftaran;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PendaftaranRepository extends JpaRepository<Pendaftaran, Long> {
+    @Override
+    Optional<Pendaftaran> findById(Long id);
+}

--- a/src/main/java/com/apb15/neorekruit/security/SecurityConfig.java
+++ b/src/main/java/com/apb15/neorekruit/security/SecurityConfig.java
@@ -42,6 +42,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/**"
                 ).permitAll();
 
+        http.authorizeRequests().antMatchers(GET, "/pengguna/pendaftar").hasAnyAuthority("ROLE_PENDAFTAR");
+        http.authorizeRequests().antMatchers(GET, "/pengguna/rekruter").hasAnyAuthority("ROLE_REKRUTER");
+
         http.authorizeRequests().antMatchers(POST, "/rekrutmen").hasAnyAuthority("ROLE_REKRUTER");
         http.authorizeRequests().antMatchers("/rekrutmen/*").hasAnyAuthority("ROLE_REKRUTER");
 

--- a/src/main/java/com/apb15/neorekruit/security/SecurityConfig.java
+++ b/src/main/java/com/apb15/neorekruit/security/SecurityConfig.java
@@ -35,17 +35,27 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 new CustomAuthenticationFilter(authenticationManagerBean());
         customAuthenticationFilter.setFilterProcessesUrl("/token/login");
 
-        http.csrf().disable();
+        http.cors().and().csrf().disable();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.authorizeRequests()
                 .antMatchers(
                 "/**"
                 ).permitAll();
+
         http.authorizeRequests().antMatchers(POST, "/rekrutmen").hasAnyAuthority("ROLE_REKRUTER");
         http.authorizeRequests().antMatchers("/rekrutmen/*").hasAnyAuthority("ROLE_REKRUTER");
+
         http.authorizeRequests().antMatchers(POST, "/rekrutmen/**/pengumuman").hasAnyAuthority("ROLE_REKRUTER");
         http.authorizeRequests().antMatchers(PUT, "/rekrutmen/**/pengumuman/*").hasAnyAuthority("ROLE_REKRUTER");
         http.authorizeRequests().antMatchers(DELETE, "/rekrutmen/**/pengumuman/*").hasAnyAuthority("ROLE_REKRUTER");
+
+        http.authorizeRequests().antMatchers(POST, "/rekrutmen/**/pendaftaran").hasAnyAuthority("ROLE_PENDAFTAR");
+        http.authorizeRequests().antMatchers(GET,"/rekrutmen/**/pendaftaran/*").hasAnyAuthority("ROLE_PENDAFTAR",
+                "ROLE_REKRUTER");
+        http.authorizeRequests().antMatchers(PUT, "/rekrutmen/**/pendaftaran/*").hasAnyAuthority("ROLE_REKRUTER");
+        http.authorizeRequests().antMatchers(POST, "/rekrutmen/**/pendaftaran/**/ubahstatus").hasAnyAuthority(
+                "ROLE_REKRUTER");
+
         http.authorizeRequests().anyRequest().authenticated();
         http.addFilter(customAuthenticationFilter);
         http.addFilterBefore(new CustomAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/apb15/neorekruit/service/PendaftarService.java
+++ b/src/main/java/com/apb15/neorekruit/service/PendaftarService.java
@@ -4,4 +4,5 @@ import com.apb15.neorekruit.model.Pendaftar;
 
 public interface PendaftarService {
     Pendaftar createPendaftar(Pendaftar pendaftar);
+    Pendaftar findByEmail(String email);
 }

--- a/src/main/java/com/apb15/neorekruit/service/PendaftarServiceImpl.java
+++ b/src/main/java/com/apb15/neorekruit/service/PendaftarServiceImpl.java
@@ -3,6 +3,7 @@ package com.apb15.neorekruit.service;
 import com.apb15.neorekruit.model.Pendaftar;
 import com.apb15.neorekruit.repository.PendaftarRepository;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.ObjectNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -11,10 +12,21 @@ import javax.transaction.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class PendaftarServiceImpl implements PendaftarService {
+    private final PenggunaService penggunaService;
     private final PendaftarRepository pendaftarRepository;
 
     @Override
     public Pendaftar createPendaftar(Pendaftar pendaftar) {
         return pendaftarRepository.save(pendaftar);
+    }
+
+    @Override
+    public Pendaftar findByEmail(String email) {
+        var pengguna = penggunaService.getPengguna(email);
+        var pendaftar = pendaftarRepository.findPendaftarByPengguna(pengguna);
+
+        if(!pendaftar.isPresent()) throw new ObjectNotFoundException(email, "Pendaftar");
+
+        return pendaftar.get();
     }
 }

--- a/src/main/java/com/apb15/neorekruit/service/PendaftaranService.java
+++ b/src/main/java/com/apb15/neorekruit/service/PendaftaranService.java
@@ -1,0 +1,11 @@
+package com.apb15.neorekruit.service;
+
+import com.apb15.neorekruit.model.Pendaftaran;
+import com.apb15.neorekruit.model.StatusPenerimaan;
+
+public interface PendaftaranService {
+    Pendaftaran createPendaftaran(Long idRekrutmen, String emailPendaftar, Pendaftaran pendaftaran);
+    Pendaftaran findPendaftaranById(Long idPendaftaran);
+    Pendaftaran updatePendaftaran(Long idRekrutmen, Long idPendaftaran, Pendaftaran pendaftaran);
+    void changeStatusPendaftaran(Long idPendaftaran, StatusPenerimaan status);
+}

--- a/src/main/java/com/apb15/neorekruit/service/PendaftaranServiceImpl.java
+++ b/src/main/java/com/apb15/neorekruit/service/PendaftaranServiceImpl.java
@@ -1,0 +1,53 @@
+package com.apb15.neorekruit.service;
+
+import com.apb15.neorekruit.model.Pendaftaran;
+import com.apb15.neorekruit.model.StatusPenerimaan;
+import com.apb15.neorekruit.repository.PendaftaranRepository;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.ObjectNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PendaftaranServiceImpl implements PendaftaranService {
+    private final RekrutmenService rekrutmenService;
+    private final PendaftarService pendaftarService;
+    private final PendaftaranRepository pendaftaranRepository;
+
+    @Override
+    public Pendaftaran createPendaftaran(Long idRekrutmen, String emailPendaftar, Pendaftaran pendaftaran) {
+        var rekrutmen = rekrutmenService.findById(idRekrutmen);
+        pendaftaran.setRekrutmen(rekrutmen);
+        var pendaftar = pendaftarService.findByEmail(emailPendaftar);
+        pendaftaran.setPendaftar(pendaftar);
+        var createdPendaftaran = pendaftaranRepository.save(pendaftaran);
+
+        return createdPendaftaran;
+    }
+
+    @Override
+    public Pendaftaran findPendaftaranById(Long idPendaftaran) {
+        var pendaftaranOptional = pendaftaranRepository.findById(idPendaftaran);
+        if(!pendaftaranOptional.isPresent()) throw new ObjectNotFoundException(idPendaftaran, "Pendaftaran");
+
+        var pendaftaran = pendaftaranOptional.get();
+        return pendaftaran;
+    }
+
+    @Override
+    public Pendaftaran updatePendaftaran(Long idRekrutmen, Long idPendaftaran, Pendaftaran pendaftaran) {
+        var oldPendaftaran = findPendaftaranById(idPendaftaran);
+        oldPendaftaran.setLinkCV(pendaftaran.getLinkCV());
+        oldPendaftaran.setLinkTugas(pendaftaran.getLinkTugas());
+
+        var updatedPendaftaran = pendaftaranRepository.save(oldPendaftaran);
+        return updatedPendaftaran;
+    }
+
+    @Override
+    public void changeStatusPendaftaran(Long idPendaftaran, StatusPenerimaan status) {
+        var pendaftaran = findPendaftaranById(idPendaftaran);
+        pendaftaran.setStatusPenerimaan(status);
+        pendaftaranRepository.save(pendaftaran);
+    }
+}


### PR DESCRIPTION
## Changes
- Implement `Pendaftaran` so `Pendaftar` can register to a `Rekrutmen` created by `Rekruter`
- Remove ID redundancy from `Pengguna` to its OneToOne relation
- Add new endpoint to `/pengguna/**` to view `Rekrutmen` created for `Rekruter` and `Pendaftaran` created for `Pendaftar`
- Remove association that included in JSON serialization of Rekrutmen to reduce database query and increases performance